### PR TITLE
Add site baseurl to css link in head tag

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>{{ page.title }}</title>
-    <link href="../css/mminail.css" rel="stylesheet">
+    <link href="{{site.baseurl}}/css/mminail.css" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
To create a relative link in Jekyll, pre-pend the hyperlink with ...
\{{site.baseurl}}/