### PR TITLE
Remove site dot baseurl from head tag links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <title>{{ page.title }}</title>
-    <link href="{{site.baseurl}}/css/mminail.css" rel="stylesheet">
-	<link type="image/x-icon" href="{{site.baseurl}}/favicon.ico" rel="icon">
+    <link href="../css/mminail.css" rel="stylesheet">
+	<link type="image/x-icon" href="/favicon.ico" rel="icon">
 </head>
 
 <body>


### PR DESCRIPTION
Site dot baseurl references the given baseurl. For this repo, the
baseurl is simply the root, or ‘/‘ slash key. This rendering operates
locally w gusto.