### PR TITLE
Text align left supporting content

### DIFF
--- a/css/mminail.css
+++ b/css/mminail.css
@@ -83,6 +83,7 @@ article#main-article {
 }
 
 aside#supporting-content {
+    text-align: left;
     /* float: right; */
     /* width: 20%; */
     background: rgb(155,155,204); /* Dark Gray */


### PR DESCRIPTION
The dot menu class justifies text. The supporting content is a member
of the dot menu. Therefore, to read diminishing responsive text, the
text-align switch must be switched to ‘left’ under the aside supporting
content ID.