### PR TITLE
Changing markdown switch in yams config file to kramdown

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 baseurl: /
 exclude: ['README.md']
-markdown: redcarpet
+markdown: kramdown
 #timezone: America/Phoenix
 #gems: octopress-date-format


### PR DESCRIPTION
To render a markdown include via the new markdown tag, the markdown
switch needs to call kramdown remotely