### PR TITLE
Using liquid comment out to render markdown tag moot

### DIFF
--- a/pages/pagefour.htm
+++ b/pages/pagefour.htm
@@ -16,7 +16,10 @@ title: Page Four | Carbon Free Footprint Project
 	<article class="main-article">
 		<!-- Comment out the tag markdown. See markdown-old dot rb in _plugins subdirectoru.
 			Not rendered ver 104 remotely ...
-		{% markdown Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md %} -->
+		{% comment %}
+		{% markdown-old Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md %}
+		{% endcomment %}
+		-->
 	</article>
 
 </div>


### PR DESCRIPTION
A liquid comment out tag must be embedded in a html comment out tag to
render the markdown tag moot