### PR TITLE
Change link from secure ssl to http

### DIFF
--- a/_includes/footer.htm
+++ b/_includes/footer.htm
@@ -6,7 +6,7 @@
 	</p>
 	
 	<p>
-		<span>This Open Source project is being hosted with <a href="https://www.jekyll.tips/" title="Click to Visit Instructional Jekyll Tips n Vids" target="_blank">Jekyll</a></span>
+		<span>This Open Source project is being hosted with <a href="http://www.jekyll.tips/" title="Click to Visit Instructional Jekyll Tips n Vids" target="_blank">Jekyll</a></span>
 		<span>via <a href="https://pages.github.com/" title="Clik to Jump To GitHub Pages" target="_blank">GitHub Pages</a></span>
 	</p>
 </div>


### PR DESCRIPTION
Jekyll tips link in the footer does not utilize ssh