### PR TITLE
Add scope and path to config dot yaml file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,16 @@
 baseurl: /
 exclude: ['README.md']
+highlighter: rouge
 markdown: kramdown
+kramdown:
+    input: GFM
+    syntax_highlighter: rouge
+defaults:
+  -
+    scope:
+      path: "" # an empty string here means all files in the project
+      # type: "pages"
+    values:
+      layout: "default"
 #timezone: America/Phoenix
 #gems: octopress-date-format

--- a/_includes/aside.htm
+++ b/_includes/aside.htm
@@ -1,5 +1,5 @@
 <hgroup class="centeralign">
-	<h3>Supporting Content</h3>
+	<h3>Supporting Content <i class="icon-large icon-eye-open"></i></h3>
 </hgroup>
 	<hr />
 
@@ -12,7 +12,7 @@
 </p>
 	<hr />
 <p>
-	<span>When residing 25 miles extant of a state legalized dispensary.</span>
+	<span>*** When residing 25 miles extant of a state legalized dispensary ***</span>
 </p>
 	<hr />
 <p>
@@ -27,14 +27,17 @@
 	<span>This is a placeholder paragraph (C).</span>
 </p>
     <hr />
+
 <p>
-	<span>Here, a block of code may be displayed and Wordwrapped in real time using triple backticks and a code language qualifier embedded in a pre and code tag combo styled via css, as follows:</span>
+	<span>Here, a block of Python code may be displayed and Wordwrapped in real time when enclosed in a liquid wrapper, as follows:</span>
 </p>
 	<hr/>
-<pre>
-<code>
-```python
 
+<!--
+<pre>
+<span>Highlighting Python code w Rouge</span>
+<code> -->
+{% highlight python linenos %}
 # Fibonacci Series:
 # The sum of two elements ...
 # Defines the next numeral ...
@@ -44,16 +47,49 @@ a, b = 0, 1
 while b < 10:
 	print(b)
 	a, b = b, a+b
-
-```
+{% endhighlight %}
+<!--
 </code>
 </pre>
+-->
 	<hr />
+
 <p>
-	<span>The css to wordwrap and highlight the lines of code from within a pre and code combo block ...</span>
+	<span>For html, enclose in a liquid wrapper with a language qualifier and a line marker, as follows:</span>
+</p>
+	<hr />
+
+{% highlight HTML linenos %}
+{\% highlight HTML linenos \%}
+<pre>
+Highlighting Html code ...
+with Rouge.
+<code>
+<p>
+The {\%liquid wrapper\%} ...
+shown here has been ...
+'defanged' with the ...
+back-slash key for ...
+illustration purposes only.
+</p>
+<p>
+To render simply the code ...
+remove the back-slashes from ...
+the liquid wrapper as above.
+</p>
+</code>
+</pre>
+{\% endhighlight \%}
+{% endhighlight %}
+
+	<hr />
+
+<p>
+	<span>Using triple backticks and a code language qualifier to wordwrap and highlight lines of css from within a pre and code combo block ...</span>
 </p>
 	<hr/>
 <pre>
+<span>Highlighting Css code w Rouge</span>
 <code>
 ```css
 

--- a/_includes/footer.htm
+++ b/_includes/footer.htm
@@ -7,4 +7,5 @@
 		<span>This Open Source project is being hosted with <a href="http://www.jekyll.tips/" title="Click to Visit Instructional Jekyll Tips n Vids" target="_blank">Jekyll</a></span>
 		<span>via <a href="https://pages.github.com/" title="Clik to Jump To GitHub Pages" target="_blank">GitHub Pages</a></span>
 	</p>
+	
 </div>

--- a/_includes/nav.htm
+++ b/_includes/nav.htm
@@ -1,7 +1,7 @@
 <nav class="menu">
     
 <hgroup class="centeralign">
-	<h3>Navigator</h3>
+	<h3>Navigator <i class="icon-large icon-screenshot"></i></h3>
 </hgroup>
     <!-- <ul class="list-inline"> -->
     <!-- <ul class="nav nav-pills nav-stacked"> -->
@@ -12,7 +12,7 @@
         <li><a href="../pages/donate.htm" class="btn btn-lg" title="Clik to Jump To the Donation Page" target="_self">Donate Page <i class="glyphicon glyphicon-thumbs-up"></i></a></li>
         <li><a href="../pages/social.htm" class="btn btn-lg" title="Clik to Jump To the Social Page" target="_self">Social Page <i class="glyphicon glyphicon-star-empty"></i></a></li>
         <li><a href="../pages/pagefive.htm" class="" title="Clik to Jump To the Page Five" target="_self">Page Five</a></li>
-        <li><a href="../pages/pagesix.htm" class="" title="Clik to Jump To the Page Six" target="_self">Page Six</a></li>
+        <li><a href="../pages/landraces.htm" class="btn btn-lg" title="Clik to Jump To the Landraces Page" target="_self">Landraces <i class="glyphicon glyphicon-leaf"></i></a></li>
         {% if page.url == '/index.htm' % }
         {% elseif page.url == '../pages/pagetwo.htm'%}
         {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,8 +37,10 @@
 <!-- <hgroup class="panel-body"> -->
 <hgroup>
 	<h2>{{ page.title }}</h2>
+	
 </hgroup>
-<p>Powered with <a href="https://www.glyphicons.com/" title="Click to Review Glyphicons" target="_blank">glyphicons</a>!</p>
+<p>Powered with <a href="https://www.glyphicons.com/" title="Click to Review Glyphicons" target="_blank">glyphicons<br /><br />
+<i class="icon-large icon-snowflake"></i></a></p>
 <footer>
 
 <!-- Place all body scripts north of the body closing tag -->

--- a/pages/landraces.htm
+++ b/pages/landraces.htm
@@ -1,0 +1,53 @@
+---
+layout: default
+title: CGRBA | Landrace Subdirectory
+---
+<hgroup class="leftalign">
+  <h3>Landraces Article</h3>
+</hgroup>
+  <hr />
+
+<p>
+	<span>Welcome! This is the Landraces page for the <b>Carbon Free Footprint</b> project.</span>
+</p>
+  <hr />
+
+<hgroup class="leftalign">
+  <h3>Landrace Subdirectory</h3>
+</hgroup>
+  <hr />
+
+<p>
+	<span>The Landrace Subdirectory serves up a menu of Landrace articles for the <b>Carbon Free Footprint</b> project.</span>
+</p>
+
+<p>
+  <span>Here, the root file ( landraces.htm ) serves with css out of the pages directory below.</span>
+  <span>But, sorry! We are not able to serve css one level beyond the pages directory into the Landrace Subdirectory at this time.</span>
+  <span>As soon as we patch the relative path to the other Landrace files in the Landrace folder at ../pages/landraces, we will lift this restriction.</span>
+  <span>The Website Management.</span>
+</p>
+	<hr />
+
+<nav class="menu">
+
+<hgroup class="centeralign">
+    <h3>Landrace Subdirectory <i class="icon-large icon-screenshot"></i></h3>
+</hgroup>
+  <hr />
+
+<footer>
+	{% include footer.htm %}
+</footer>
+
+<ul class="nav nav-stacked">
+  <li><a href="../pages/landraces.htm" class="btn btn-lg" title="Clik to Jump To the Landraces Page" target="_self">Landraces dot htm</a></li>
+ 
+  <!-- Unable to serve css one level beyond the pages subdirectory ... Here, the file serves without css in the landraces subdirectory
+  <li><a href="../pages/landraces/newlandrace.htm" class="btn btn-lg" title="Clik to Jump To the New Landrace phenotype Page" target="_self">NewLandRace phenotype</a></li>
+  <li><a href="../pages/landraces/ruderalis.htm" class="btn btn-lg" title="Clik to Jump To the Ruderalis phenotype Page" target="_self">Ruderalis phenotype</a></li>
+-->
+
+</ul>
+  
+</nav>

--- a/pages/landraces/newlandrace.htm
+++ b/pages/landraces/newlandrace.htm
@@ -1,0 +1,21 @@
+---
+layout: default
+title: New Landrace Page | Carbon Free Footprint Project
+---
+<hgroup class="leftalign">
+	<h3>New Landrace</h3>
+</hgroup>
+	<hr />
+	
+<p>
+	<span>Welcome! This is the New Landrace page of the <b>Carbon Free Footprint</b> project.</span>
+</p>
+
+<p>
+	<span>More to come ...</span>
+</p>
+	<hr />
+
+<footer>
+	{% include footer.htm %}
+</footer>

--- a/pages/landraces/ruderalis.htm
+++ b/pages/landraces/ruderalis.htm
@@ -1,0 +1,40 @@
+---
+layout: default
+title: CGRBA | Ruderalis phenotype
+---
+<hgroup class="leftalign">
+  <h3>Ruderalis Article</h3>
+</hgroup>
+  <hr />
+
+<p>
+	<span>Welcome! This is the home page for the <b>Ruderalis phenotype</b> project.</span>
+</p>
+  <hr />
+
+<p>
+	<span>More to come ...</span>
+</p>
+	<hr />
+
+<nav class="menu">
+
+<hgroup class="centeralign">
+    <h3>Landraces <i class="icon-large icon-screenshot"></i></h3>
+</hgroup>
+
+<ul class="nav nav-stacked">
+  <li><a href="../pages/ruderalis2.htm" class="btn btn-lg" title="Clik to Jump To the Ruderalis phenotype Page" target="_self">Ruderalis phenotype</a></li>
+
+  <!-- Unable to serve css one level beyond the pages subdirectory ... Here, the file serves without css in the landraces subdirectory
+  <li><a href="../pages/landraces/newlandrace.htm" class="btn btn-lg" title="Clik to Jump To the Ruderalis phenotype Page" target="_self">NewLandRace phenotype</a></li>
+-->
+
+</ul>
+
+</nav>
+  <hr />
+  
+<footer>
+	{% include footer.htm %}
+</footer>

--- a/pages/markdown_rb_notes.htm
+++ b/pages/markdown_rb_notes.htm
@@ -5,3 +5,21 @@
 		{% markdown-old Canna_BC_Northern_Lights_Carbon_Free_Footprint_Solar_Electricty_Notes.md %}
 		{% endcomment %}
 		-->
+
+<!-- Comment out liquid tags separately ...
+
+{% comment %}
+
+{\%
+
+\%}
+
+{% endcomment %}
+
+Comment out html tags from within an html comment tag
+
+<li><a href="../pages/landraces/Russian.cshtml">Russian</a></li>
+<li><a href="../pages/landraces/Mongolian.cshtml">Mongolian</a></li>
+<li><a href="../pages/landraces/Unknown_landrace.cshtml">Unknown</a></li>
+
+-->

--- a/pages/search.htm
+++ b/pages/search.htm
@@ -1,0 +1,6 @@
+<!--
+<form actiion="/search.html" method="get">
+	<label for="search_box">Search</label>
+	<input type="text" id="search_box" name="query">
+	<input type="submit" value="search">
+</form> -->


### PR DESCRIPTION
In an effort to serve css beyond the pages directory into the landraces
subdirectory; Changes to aside; footer include; nav include; Default
layout; Add landraces dot htm; newlandrace dot htm, ruderalis dot htm;
A comment out instruction in rb_notes dot htm; Cracked ice on future
search form