### PR TITLE
Add read more script

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,6 +45,9 @@
 
 <!-- Place all body scripts north of the body closing tag -->
 
+<!-- Comment Out: Readmore body script 
+<script src="../js/scripts/readmore.js"></script> -->
+
 <!-- Comment Out: Prism body script
 <script src="../js/prism.js"</script>
 	Note: the switch 'data-manual'' may be added AFTER the src to invoke No highlight -->

--- a/css/mminail.css
+++ b/css/mminail.css
@@ -74,6 +74,11 @@ i.largo {
     font-size: xx-large;
 }
 
+.more-link {
+    display: inline-block;
+    margin-left: 10px;
+}
+
 /* Set the rule for the <hr> 'hard return' tag */
 .green-groove {
     border: 1px groove green;

--- a/js/scripts/readmore.js
+++ b/js/scripts/readmore.js
@@ -1,0 +1,22 @@
+var newLink = document.createElement( "a" );
+var allParagraphs = document.getElementsByTagName( "p" );
+var firstParagraph = allParagraphs[ 0 ];
+
+newLink.setAttribute( "href", "#" );
+newLink.innerHTML = "Read more";
+
+//newLink.style.display = "inline-block";
+//newLink.style.marginLeft = "10px";
+
+//Better to place styling in the css file
+newLink.setAttribute( "class", "more-link" );
+
+for( var i = 0; i < allParagraphs.length; i++ ) {
+    //console.log( allParagraphs[ i ] );
+    if( i === 0 ) {
+            continue;
+    }
+    allParagraphs[ i ].style.display = "none";
+}
+
+firstParagraph.appendChild( newLink );


### PR DESCRIPTION
The read more script adds a link via javascript when invoked on the
page to hide all paragraphs subsequent to the first. The reader may the
click and review the balance of the text. This method must be done on a
page-by-page basis. Globally, the script will run havoc.