### PR TITLE
Serving jQuery Mobile securely

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -82,7 +82,7 @@
 <script src="../js/jquery.mobile.min.js"></script> -->
 
 <!-- Comment Out: Jquery Mobile Library remote script -->
-<script src="http://ajax.googleapis.com/ajax/libs/jquerymobile/1.4.5/jquery.mobile.min.js"></script> 
+<script src="https://ajax.googleapis.com/ajax/libs/jquerymobile/1.4.5/jquery.mobile.min.js"></script> 
 
 <!-- Comment Out: Tether Library Local script 
 <script src="../js/tether.min.js"></script> -->


### PR DESCRIPTION
Google Chrome demands https v http for jQuery Mobile rendering