### PR TITLE
Add Img-circle to Highlight Reel

### DIFF
--- a/Html5/Convert-To-SVG.htm
+++ b/Html5/Convert-To-SVG.htm
@@ -122,6 +122,16 @@ img {
 {% endhighlight %}
 </pre>
 
+
+<pre>
+<span>Creating the css for a circle image ( from Bootstrap ) ...</span>
+{% highlight css %}
+.img-circle {
+  border-radius: 50%;
+}
+{% endhighlight %}
+</pre>
+
 <pre>
 <span>Drawing on the fly w Javascript ...</span>
 {% highlight javascript %}


### PR DESCRIPTION
Bootstrap provides a default css for img-circle