### PR TITLE
Removing text hyperlink; Replace w alt text

### DIFF
--- a/Html5/Convert-To-SVG.htm
+++ b/Html5/Convert-To-SVG.htm
@@ -186,7 +186,7 @@ alt="Medical Marijuana Initiative of North America
 	<span>For the image, alternatively, you may simply copy and paste the URL for the SVG image into your browser window to display the image, as follows:</span>
 	<a href="https://mminail.github.io/images/MMINAIL-Logo-Badge-Original-Registered-Transparent-320-x-320-px.svg"
 	title="Click To Review the Medical Marijuana Initiative of North America - International Limited USPTO Registered Logo Badge in (.svg) format"
-	target="_blank">https://mminail.github.io/images/MMINAIL-Logo-Badge-Original-Registered-Transparent-320-x-320-px.svg</a>.</span>
+	target="_blank">SVG Image</a>.</span>
 </p>
 
 <footer class="page-footer center-block">


### PR DESCRIPTION
Not a good idea to display full URLs, when a hyperlink exists use alt
text