### PR TITLE
Instructions to remove illegal right-arrow carriage return

### DIFF
--- a/Javascript/square-it.htm
+++ b/Javascript/square-it.htm
@@ -76,7 +76,11 @@ let SQ = (nbr) => {
 </p>
 
 <p>
-    <span>You will now wish to go ahead and copy and paste the above code into the program entry line at the bottom of the console.</span> 
+	<span>You will now wish to go ahead and copy and paste the above code into the program entry line at the bottom of the console after removing the illegal right-arrow <code>➡️ </code> carriage returns from the code, if any.</span> 
+</p>
+
+<p>
+	<span>Or ...</span>
 </p>
 
 <p>


### PR DESCRIPTION
Cannot keep right-arrow carriage returns in code when loading to
Firefox Web Console bottom entry line