### PR TITLE
Update aside to accept req hyperlink

### DIFF
--- a/_includes/aside.htm
+++ b/_includes/aside.htm
@@ -9,6 +9,13 @@
 	<hr />
 
 <p>
+	<span><b>Note</b>.</span>
+	<span>The Http Headers of this repo are being monitored by </span>
+	<a href="http://internetsupervision.com/" title="Site Monitoring - InternetSupervision.com" target="_blank">Internet Supervision dot com</a>
+</p>
+	<hr />
+
+<p>
 	<span>This page has been tested for mobile responsiveness on a virtual Galaxy S5 smartphone emulator</span>
 </p>
 	<hr />
@@ -151,3 +158,4 @@
 <p>
 	<span class="script-text">The Management</span>
 </p>
+


### PR DESCRIPTION
Internet Supervision dot com require a presence at the aside to
accommodate the free Http Header monitoring of each page at the repo