### PR TITLE
Rename python module

### DIFF
--- a/jQuery/Resume-Builder.htm
+++ b/jQuery/Resume-Builder.htm
@@ -46,15 +46,14 @@ title: Resume Builder | MMINAIL
 <pre class='flex-box'>
 <span>Check to see if all of assets of the page have been loaded</span>
 {% highlight javascript linenos %}
-jKey.addEventListener("load", function($) {
-    window.alert(`All of the assets are now loaded.`);
+	// More to come ...
 });
 {% endhighlight %}
 <span>Time the load, as well</span>
 </pre>
 <hr class='green-groove' />
 
-<p>
+<p id="mminail">
 	<span>More to come ...</span>
 </p>
 

--- a/js/scripts/resume-builder.js
+++ b/js/scripts/resume-builder.js
@@ -32,6 +32,11 @@ jKey(function($) {
     //Append author to the parent tag of the id
     rht.append(`${author}`);
 });
+
+jKey(window).load(function($) { 
+    window.alert(`All of the assets are now loaded.`);
+});
+
 //Build a URL programatically #1
 jKey(function($) {
     //Declare and initialize the var target id wrapper set
@@ -54,6 +59,7 @@ jKey(function($) {
 }); */
 
 //Check to see if all of the page assets have been loaded
-jKey.addEventListener("load", function($) {
+/* jKey.addEventListener("load", function($) {
     window.alert(`All of the assets are now loaded.`);
-});
+}); */
+

--- a/py/scripts/test-python.py
+++ b/py/scripts/test-python.py
@@ -1,2 +1,0 @@
-
-print "Hello, World!"

--- a/py/scripts/test_python.py
+++ b/py/scripts/test_python.py
@@ -1,0 +1,7 @@
+#This is a python comment
+"""
+This is a Python module docstring.
+A Python module docstring can be multi-line.
+All Python module docstring(s) must be enveloped in triple quotes.
+"""
+print "Hello, World!"


### PR DESCRIPTION
Python module (.py) name words may be separated by an underscore, not a hyphen; Improve Resume-Builder (.htm) and accompanying (.js)