### PR TITLE
Another front matter ref to YAML

### DIFF
--- a/Jekyll/liquid-wrappers.htm
+++ b/Jekyll/liquid-wrappers.htm
@@ -184,12 +184,12 @@ Code Block w White    Space
 	<hr class='green-groove' />
 
 <hgroup class='text-left'>
-	<h4>Page Front Matter</h4>
+	<h4>YAML Front Matter</h4>
 </hgroup>
 	<hr class='green-groove' />
 
 <p>
-	<span>Similar to the front matter area of a cshtml page, the Liquid templating language allows for the declaration of variables and arrays via the front matter section of the page.</span>
+	<span>Similar to the front matter area of a cshtml page, the Liquid templating language allows for the declaration of variables and arrays via the YAML language in the front matter section of the page.</span>
 </p>
 
 <p>


### PR DESCRIPTION
YAML controls the front matter of a Liquid page when served via Jekyll