### PR TITLE
Remove ( .svg ) from LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.svg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Unable to render ( .svg ) remotely when enabled