### PR TITLE
Update Annual Report Page

### DIFF
--- a/Governance/Annual-Report-2020.htm
+++ b/Governance/Annual-Report-2020.htm
@@ -67,12 +67,12 @@ title: Annual Report 2020
     <hr class='green-groove' />
 
     <hgroup class='text-left'>
-      <h4>New Issue #2</h4>
+      <h4>Conveyance</h4>
     </hgroup>
     <hr class='green-groove' />
 
     <p>
-      <span>None ...</span>
+      <span><b>Note</b>. In the event of a transfer of the ownership of the USPTO trademark from Robert Weber, Owner to the Benefit corporate entity of which Mr Weber is the primary and only shareholder, then a formal `Conveyance` will be constructed and entered into the Electronic Trademark Assignment System of the USPTO under the tab named `Entity Conversion`.</span>
     </p>
 
     <p>


### PR DESCRIPTION
Publishing note of required conveyance in the event of a transfer of ownership of the trademark via the `Entity Conversion` tab of the USPTO's ETAS.