### PR TITLE
Update activesupport

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -237,7 +237,8 @@ gem 'jekyll', '3.9.3'
 gem 'rubyzip', '2.0.0'
 #
 # github-pages, 175 requires activesupport, 429
-gem 'activesupport', '6.0.3.1'
+# gem 'activesupport', '6.0.3.1'
+gem 'activesupport', '6.0.6.1'
 #
 gem 'github-pages-health-check', '1.17.9'
 #

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.1)
+    activesupport (6.0.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -256,7 +256,7 @@ PLATFORMS
   x86_64-darwin-19
 
 DEPENDENCIES
-  activesupport (= 6.0.3.1)
+  activesupport (= 6.0.6.1)
   github-pages (= 228)
   github-pages-health-check (= 1.17.9)
   html-pipeline (= 2.14.3)


### PR DESCRIPTION
Dependbot calls for 6.0.3.1 to 6.0.6.1 update of activesupport